### PR TITLE
Add "How to develop" to README.md

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "arcanis.vscode-zipfs",
+    "dbaeumer.vscode-eslint"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "search.exclude": {
+    "**/.yarn": true,
+    "**/.pnp.*": true
+  },
+  "eslint.nodePath": ".yarn/sdks",
+  "typescript.tsdk": ".yarn/sdks/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "editor.formatOnSave": true
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-The superflat site
+# The superflat site
+
+## How to develop
+
+```bash
+yarn install
+yarn dlx @yarnpkg/sdks vscode
+```
+
+Optionally install the recommended extensions `arcanis.vscode-zipfs` and `dbaeumer.vscode-eslint`.
+
+```bash
+yarn dev
+```


### PR DESCRIPTION
I had some minor trouble with VSCode not supporting Yarn's [Plug'n'Play](https://yarnpkg.com/features/pnp), so I thought I'd document it.